### PR TITLE
Don't require nightly

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -7,6 +7,7 @@ use kaolin::{
 };
 use test::{Bencher, black_box};
 
+#[path = "../tests/common.rs"]
 mod common;
 use common::*;
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,9 +6,12 @@ use alloc::{collections::VecDeque, string::String};
 
 use crate::{elements::flexbox::FlexBox, style::border};
 
+/// Placeholder for when [RenderCommand::Custom] isn't used.
+pub enum Nothing {}
+
 /// A single rendering command.
 #[derive(Debug, Clone)]
-pub enum RenderCommand<Color, CustomData = !>
+pub enum RenderCommand<Color, CustomData = Nothing>
 where
     Color: Default + Copy + PartialEq + crate::style::KaolinColor,
 {

--- a/src/elements/traits.rs
+++ b/src/elements/traits.rs
@@ -1,5 +1,6 @@
 use alloc::boxed::Box;
 
+use crate::commands::Nothing;
 use crate::elements::KaolinNode;
 use crate::elements::RenderCommand;
 use crate::style::sizing::PreferredSize;
@@ -14,7 +15,7 @@ use crate::style::sizing::SizingDimensions;
 /// although that data will need to be consistent across all elements for a specific renderer.
 ///
 /// For elements that can contain other elements, also implement the [`KaolinContainerElement`] trait.
-pub trait KaolinElement<'frame, Color, CustomData = !>
+pub trait KaolinElement<'frame, Color, CustomData = Nothing>
 where
     Color: Default + Copy + PartialEq + crate::style::KaolinColor,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(never_type)]
 #![no_std]
 #[doc = include_str!("../README.md")]
 extern crate alloc;


### PR DESCRIPTION
I also moved the benchmarks to the canonical `benches` folder, as I think they didn't get run with `cargo bench` before.